### PR TITLE
Add UDP broadcast service

### DIFF
--- a/SmartUI/SmartUI/AppDelegate.m
+++ b/SmartUI/SmartUI/AppDelegate.m
@@ -8,6 +8,7 @@
 #import "AppDelegate.h"
 #import "ViewController.h"
 #import "CommonUtils.h"
+#import "UDPManager.h"
 #import <insideSDK/InsideSDK.h>
 #import <IQKeyboardManager/IQKeyboardManager.h>
 @interface AppDelegate ()
@@ -31,7 +32,10 @@
     self.window.backgroundColor = [UIColor whiteColor];
     self.window.rootViewController = nav;
     [self.window makeKeyAndVisible];
-    
+
+    // Start UDP listener on port 12306
+    [[UDPManager sharedInstance] startListening];
+
     return YES;
 }
 

--- a/SmartUI/SmartUI/VC/SmartUI-Bridging-Header.h
+++ b/SmartUI/SmartUI/VC/SmartUI-Bridging-Header.h
@@ -7,3 +7,4 @@
 #import "NSString+Base64After3DES.h"
 #import <WtvASRSDK/WtvASRSDK.h>
 #import <IQKeyboardManager/IQKeyboardManager.h>
+#import "UDPManager.h"

--- a/SmartUI/SmartUI/utils/CommonUtils.h
+++ b/SmartUI/SmartUI/utils/CommonUtils.h
@@ -17,6 +17,9 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString *)decryptAES128WithBase64String:(NSString *)base64String key:(NSString *)key;
 
 -(void)voiceRecognitionService:(NSURL *)fileUrl;
+
+/// Send a UDP message which can be triggered from H5
+- (void)sendUDPMessage:(NSString *)message broadcastIP:(NSString *)ip;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SmartUI/SmartUI/utils/CommonUtils.m
+++ b/SmartUI/SmartUI/utils/CommonUtils.m
@@ -8,6 +8,7 @@
 #import "CommonUtils.h"
 #import <CommonCrypto/CommonCrypto.h>
 #import <WtvASRSDK/WtvASRSDK.h>
+#import "UDPManager.h"
 @implementation CommonUtils
 
 + (instancetype)sharedInstance{
@@ -15,6 +16,7 @@
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         _sharedInstance = [[CommonUtils alloc] init];
+        [[NSNotificationCenter defaultCenter] addObserver:_sharedInstance selector:@selector(handleUDPMessage:) name:UDPManagerDidReceiveNotification object:nil];
     });
     return _sharedInstance;
 }
@@ -36,6 +38,19 @@
             NSLog(@"识别的文字：%@",msg);
         }
     }];
+}
+
+// JS 调用此方法发送 UDP 广播
+- (void)sendUDPMessage:(NSString *)message broadcastIP:(NSString *)ip {
+    if (ip.length > 0) {
+        [UDPManager sharedInstance].broadcastAddress = ip;
+    }
+    [[UDPManager sharedInstance] sendMessage:message];
+}
+
+- (void)handleUDPMessage:(NSNotification *)noti {
+    NSString *msg = noti.userInfo[UDPManagerMessageKey];
+    NSLog(@"Received UDP message: %@", msg);
 }
 
 

--- a/SmartUI/SmartUI/utils/udp/UDPManager.h
+++ b/SmartUI/SmartUI/utils/udp/UDPManager.h
@@ -1,0 +1,25 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Notification when a UDP message is received
+extern NSString * const UDPManagerDidReceiveNotification;
+/// Key for the message string inside the notification userInfo
+extern NSString * const UDPManagerMessageKey;
+
+@interface UDPManager : NSObject
+
++ (instancetype)sharedInstance;
+
+/// Broadcast address, default 255.255.255.255
+@property (nonatomic, copy) NSString *broadcastAddress;
+
+/// Start listening on port 12306
+- (void)startListening;
+
+/// Send message to current broadcast address on port 12306
+- (void)sendMessage:(NSString *)message;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SmartUI/SmartUI/utils/udp/UDPManager.m
+++ b/SmartUI/SmartUI/utils/udp/UDPManager.m
@@ -1,0 +1,96 @@
+#import "UDPManager.h"
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+NSString * const UDPManagerDidReceiveNotification = @"UDPManagerDidReceiveNotification";
+NSString * const UDPManagerMessageKey = @"message";
+
+@interface UDPManager ()
+{
+    int _socketFD;
+    struct sockaddr_in _broadcastAddr;
+    dispatch_queue_t _queue;
+}
+@end
+
+@implementation UDPManager
+
++ (instancetype)sharedInstance {
+    static UDPManager *mgr;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        mgr = [[self alloc] init];
+    });
+    return mgr;
+}
+
+- (instancetype)init {
+    if (self = [super init]) {
+        _queue = dispatch_queue_create("com.example.udp", DISPATCH_QUEUE_SERIAL);
+        self.broadcastAddress = @"255.255.255.255";
+    }
+    return self;
+}
+
+- (void)setBroadcastAddress:(NSString *)broadcastAddress {
+    _broadcastAddress = [broadcastAddress copy];
+    memset(&_broadcastAddr, 0, sizeof(_broadcastAddr));
+    _broadcastAddr.sin_len = sizeof(_broadcastAddr);
+    _broadcastAddr.sin_family = AF_INET;
+    _broadcastAddr.sin_port = htons(12306);
+    inet_aton(_broadcastAddress.UTF8String, &_broadcastAddr.sin_addr);
+}
+
+- (void)startListening {
+    if (_socketFD > 0) return;
+    _socketFD = socket(AF_INET, SOCK_DGRAM, 0);
+    if (_socketFD <= 0) {
+        perror("socket");
+        return;
+    }
+    int yes = 1;
+    setsockopt(_socketFD, SOL_SOCKET, SO_BROADCAST, &yes, sizeof(yes));
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_len = sizeof(addr);
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(12306);
+    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    if (bind(_socketFD, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        perror("bind");
+        close(_socketFD);
+        _socketFD = 0;
+        return;
+    }
+
+    dispatch_async(_queue, ^{
+        while (1) {
+            char buf[1024];
+            struct sockaddr_in from;
+            socklen_t len = sizeof(from);
+            ssize_t n = recvfrom(self->_socketFD, buf, sizeof(buf) - 1, 0, (struct sockaddr *)&from, &len);
+            if (n > 0) {
+                buf[n] = '\0';
+                NSString *msg = [NSString stringWithUTF8String:buf];
+                [[NSNotificationCenter defaultCenter] postNotificationName:UDPManagerDidReceiveNotification object:self userInfo:@{UDPManagerMessageKey: msg}];
+            } else if (n < 0) {
+                perror("recvfrom");
+            }
+        }
+    });
+}
+
+- (void)sendMessage:(NSString *)message {
+    if (_socketFD <= 0) {
+        [self startListening];
+    }
+    const char *msg = [message UTF8String];
+    ssize_t len = sendto(_socketFD, msg, strlen(msg), 0, (struct sockaddr *)&_broadcastAddr, sizeof(_broadcastAddr));
+    if (len < 0) {
+        perror("sendto");
+    }
+}
+
+@end
+


### PR DESCRIPTION
## Summary
- introduce `UDPManager` for sending and receiving UDP broadcast messages
- expose UDP send API in `CommonUtils`
- start UDP listener from `AppDelegate`
- make Swift accessible to new manager via bridging header

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6847cba796788321bd51bcad8aa734c6